### PR TITLE
Clean up hard coded settings in RemoteSSH build

### DIFF
--- a/lib/mix/tasks/build.ex
+++ b/lib/mix/tasks/build.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Bootleg.Build do
     _mix_env = Application.get_env(:bootleg, :mix_env, "prod")
     version = Mix.Project.config[:version]
     config = Application.get_env(:bootleg, :build)
-    strategy = config[:strategy]
+    strategy = config[:strategy] || Bootleg.Strategies.Build.RemoteSSH
     
     config
     |> strategy.init


### PR DESCRIPTION
Noticed there was still some hard coded bits in here while working on the deploy piece