### PR TITLE
Correct the naming of local cached tarball

### DIFF
--- a/lib/strategies/build/RemoteSSH.ex
+++ b/lib/strategies/build/RemoteSSH.ex
@@ -130,7 +130,7 @@ defmodule Bootleg.Strategies.Build.RemoteSSH do
   defp download_release_archive(conn, workspace, app, version, target_mix_env) do
     remote_path = "#{workspace}/_build/#{target_mix_env}/rel/#{app}/releases/#{version}/#{app}.tar.gz"
     local_archive_folder = "#{File.cwd!}/releases"
-    local_path = Path.join(local_archive_folder, "#{app}-#{version}.tar.gz")
+    local_path = Path.join(local_archive_folder, "build.tar.gz")
 
     IO.puts "Downloading release archive"
     IO.puts " -> remote: #{remote_path}"

--- a/lib/strategies/deploy/remote_ssh.ex
+++ b/lib/strategies/deploy/remote_ssh.ex
@@ -34,7 +34,7 @@ defmodule Bootleg.Strategies.Deploy.RemoteSSH do
   defp deploy_release_archive(conn, workspace, app, version) do
     remote_path = "#{workspace}/#{app}.tar.gz"
     local_archive_folder = "#{File.cwd!}/releases"
-    local_path = Path.join(local_archive_folder, "#{app}-#{version}.tar.gz")
+    local_path = Path.join(local_archive_folder, "#{version}.tar.gz")
 
     IO.puts "Uploading release archive"
     IO.puts " <-  local: #{local_path}"

--- a/test/strategies/build/remote_ssh_test.exs
+++ b/test/strategies/build/remote_ssh_test.exs
@@ -18,7 +18,7 @@ defmodule Bootleg.Strategies.Build.RemoteSSHTest do
       workspace_setup: workspace_setup,
       config: %Bootleg.Config{
                 app: "bootleg",
-                version: "1",
+                version: "1.0.0",
                 build: %Bootleg.BuildConfig{
                   identity: "identity",
                   workspace: "workspace",
@@ -39,7 +39,7 @@ defmodule Bootleg.Strategies.Build.RemoteSSHTest do
   end
 
   test "build", %{config: config, workspace_setup: workspace_setup} do
-    local_file = "#{File.cwd!}/releases/bootleg-1.tar.gz"
+    local_file = "#{File.cwd!}/releases/build.tar.gz"
     Bootleg.Strategies.Build.RemoteSSH.build(config)
     assert_received({Bootleg.SSH, :start})
     assert_received({Bootleg.SSH, :connect, ["host", "user", "identity"]})
@@ -50,6 +50,6 @@ defmodule Bootleg.Strategies.Build.RemoteSSHTest do
     assert_received({Bootleg.SSH, :run!, [:conn, ["APP=bootleg MIX_ENV=test mix local.rebar --force", "APP=bootleg MIX_ENV=test mix local.hex --force", "APP=bootleg MIX_ENV=test mix deps.get --only=prod"], "workspace"]})
     assert_received({Bootleg.SSH, :run!, [:conn, ["APP=bootleg MIX_ENV=test mix deps.compile", "APP=bootleg MIX_ENV=test mix compile"], "workspace"]})
     assert_received({Bootleg.SSH, :run!, [:conn, "APP=bootleg MIX_ENV=test mix release", "workspace"]})
-    assert_received({Bootleg.SSH, :download, [:conn, "workspace/_build/test/rel/bootleg/releases/1/bootleg.tar.gz", ^local_file, []]})
+    assert_received({Bootleg.SSH, :download, [:conn, "workspace/_build/test/rel/bootleg/releases/1.0.0/bootleg.tar.gz", ^local_file, []]})
   end
 end

--- a/test/strategies/deploy/remote_ssh_test.exs
+++ b/test/strategies/deploy/remote_ssh_test.exs
@@ -13,7 +13,7 @@ defmodule Bootleg.Strategies.Deploy.RemoteSSHTest do
       deploy_setup: deploy_setup,
       config: %Bootleg.Config{
                 app: "bootleg",
-                version: "1",
+                version: "1.0.0",
                 deploy: %Bootleg.DeployConfig{
                   identity: "identity",
                   workspace: "workspace",
@@ -31,7 +31,7 @@ defmodule Bootleg.Strategies.Deploy.RemoteSSHTest do
   end
 
   test "deploy", %{config: config, deploy_setup: deploy_setup} do
-    local_file = "#{File.cwd!}/releases/bootleg-1.tar.gz"
+    local_file = "#{File.cwd!}/releases/1.0.0.tar.gz"
     Bootleg.Strategies.Deploy.RemoteSSH.deploy(config)  
     assert_received({Bootleg.SSH, :start})
     assert_received({Bootleg.SSH, :connect, ["host", "user", "identity"]})


### PR DESCRIPTION
This is a bit late, but corrects an inconsistency in the name of the cached tarball we suck down post-build. It was calling it `{app}-{version}.tar.gz` when storing it, but this naming is only temporary and so should be indicated. Since we're storing the temporary tarball in the `releases` directory it can appear a little confusing.