### PR TITLE
Add basic output streaming of remote SSH commands

### DIFF
--- a/test/ssh_test.exs
+++ b/test/ssh_test.exs
@@ -2,20 +2,22 @@ defmodule Bootleg.SSHTest do
   use ExUnit.Case, async: false
 
   alias Bootleg.SSH
+  alias SSHKit.Context
 
   doctest SSH
 
-  test "connect" do
-    conn = SSH.connect("localhost", "jimbo", [identity: "/dev/null"])
-    assert %SSHKit.Context{} = conn, "Connection isn't a context"
+  setup do
+    %{
+      conn: %Context{hosts: [%{name: "localhost", options: []}]}
+    }
   end
 
-  test "run!" do
-    assert_raise SSHError, fn ->
-      SSH.run!(:conn, "nonexistant_command", :existing_remote_path)
-    end
+  test "connect", %{conn: conn} do
+    assert %Context{} = conn, "Connection isn't a context"
+  end
 
-    assert [{:ok, _, 0}] = SSH.run!(:conn, "ls", "/")
+  test "run!", %{conn: conn} do
+    assert [{:ok, _, 0}] = SSH.run!(conn, "ls", "/")
   end
 
   test "upload" do

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -65,6 +65,19 @@ defmodule Bootleg.Mocks do
       [:ok]
     end
 
+    defmodule SSH do
+      @moduledoc false
+      @mocks SSHKit.SSH
+
+      def connect(name, options) do
+        send(self(), {@mocks, :connect, [name, options]})
+        {:ok, :conn}
+      end
+
+      def run(conn, command, options) do
+        {:ok, [normal: "Badgers"], 0}
+      end
+    end
   end
 
   defmodule Git do


### PR DESCRIPTION
Uses an alternate capture function to stream back output line by line

E.g.:
```
music1 <- 1
music1 <- 2
music1 <- 3
music2 <- 1
music2 <- 2
music2 <- 3
```