### PR TITLE
Rename `host` config option to `hosts`

### DIFF
--- a/lib/bootleg.ex
+++ b/lib/bootleg.ex
@@ -79,7 +79,7 @@ defmodule Bootleg do
       ```
       config :bootleg, deploy: [
         strategy: Bootleg.Strategies.Deploy.RemoteSSH,
-        host: "build1.example.com",
+        hosts: ["deploy1.example.com","deploy2.example.com"]
         user: "jane",
         workspace: "/usr/local/my_app/release"
       ]
@@ -87,7 +87,7 @@ defmodule Bootleg do
     """
 
     @doc false
-    defstruct [:workspace, :identity, :host, :strategy, :user]
+    defstruct [:workspace, :identity, :hosts, :strategy, :user]
 
     @doc """
     Creates a `Bootleg.DeployConfig` struct.
@@ -99,7 +99,7 @@ defmodule Bootleg do
       %__MODULE__{
         workspace: config[:workspace],
         identity: config[:identity],
-        host: config[:host],
+        hosts: config[:hosts],
         strategy: config[:strategy],
         user: config[:user]
       }
@@ -115,7 +115,7 @@ defmodule Bootleg do
       * `workspace` - Absolute path to the directory where the deploy can be found.
       * `strategy` - The bootleg strategy to use for administration. Defaults to `Bootleg.Strategies.Administration.RemoteSSH`.
       * `user` - The username to use when connecting to the deployment host.
-      * `host` - The hostname or IP of the deployment host.
+      * `hosts` - The hostname(s) or IP(s) of the deployment host(s).
       * `identity` - Absolute path to a private key used to authenticate with the deployment host. This should be in `PEM` format.
 
     ## Example
@@ -123,7 +123,7 @@ defmodule Bootleg do
       ```
       config :bootleg, administration: [
         strategy: Bootleg.Strategies.Administration.RemoteSSH,
-        host: "build1.example.com",
+        hosts: ["prod1.example.com","prod2.example.com"],
         user: "jane",
         workspace: "/usr/local/my_app/release"
       ]
@@ -131,7 +131,7 @@ defmodule Bootleg do
     """
 
     @doc false
-    defstruct [:workspace, :identity, :host, :strategy, :user]
+    defstruct [:workspace, :identity, :hosts, :strategy, :user]
 
     @doc """
     Creates a `Bootleg.AdministrationConfig` struct.
@@ -143,7 +143,7 @@ defmodule Bootleg do
       %__MODULE__{
         workspace: config[:workspace],
         identity: config[:identity],
-        host: config[:host],
+        hosts: config[:hosts],
         strategy: config[:strategy],
         user: config[:user]
       }

--- a/lib/strategies/administration/remote_ssh.ex
+++ b/lib/strategies/administration/remote_ssh.ex
@@ -5,12 +5,12 @@ defmodule Bootleg.Strategies.Administration.RemoteSSH do
 
   alias Bootleg.{Config, AdministrationConfig}
 
-  @config_keys ~w(host user workspace)
+  @config_keys ~w(hosts user workspace)
 
-  def init(%Config{administration: %AdministrationConfig{identity: identity, host: host, user: user, workspace: workspace} = config}) do
+  def init(%Config{administration: %AdministrationConfig{identity: identity, hosts: hosts, user: user, workspace: workspace} = config}) do
     with :ok <- Bootleg.check_config(config, @config_keys),
          :ok <- @ssh.start() do
-           @ssh.connect(host, user, [identity: identity, workspace: workspace])
+           @ssh.connect(hosts, user, [identity: identity, workspace: workspace])
     else
       {:error, msg} -> raise "Error: #{msg}"
     end

--- a/lib/strategies/deploy/remote_ssh.ex
+++ b/lib/strategies/deploy/remote_ssh.ex
@@ -5,17 +5,17 @@ defmodule Bootleg.Strategies.Deploy.RemoteSSH do
 
   alias Bootleg.{Config, DeployConfig}
 
-  @config_keys ~w(host user identity workspace)
+  @config_keys ~w(hosts user identity workspace)
 
   def deploy(%Config{version: version, app: app, deploy: %DeployConfig{}} = config) do
     conn = init(config)
     deploy_release_archive(conn, app, version)
   end
 
-  def init(%Config{deploy: %DeployConfig{identity: identity, workspace: workspace, host: host, user: user} = config}) do
+  def init(%Config{deploy: %DeployConfig{identity: identity, workspace: workspace, hosts: hosts, user: user} = config}) do
     with :ok <- Bootleg.check_config(config, @config_keys),
          :ok <- @ssh.start(),
-         conn <- @ssh.connect(host, user, [identity: identity, workspace: workspace]) do
+         conn <- @ssh.connect(hosts, user, [identity: identity, workspace: workspace]) do
       conn
     else
       {:error, msg} -> raise "Error: #{msg}"

--- a/test/strategies/administration/remote_ssh_test.exs
+++ b/test/strategies/administration/remote_ssh_test.exs
@@ -14,7 +14,7 @@ defmodule Bootleg.Strategies.Administration.RemoteSSHTest do
             %Bootleg.AdministrationConfig{
               identity: "identity",
               workspace: ".",
-              host: "host",
+              hosts: "host",
               user: "user"
             }
         },
@@ -26,7 +26,7 @@ defmodule Bootleg.Strategies.Administration.RemoteSSHTest do
             %Bootleg.AdministrationConfig{
               identity: nil,
               "workspace": "what",
-              host: nil
+              hosts: nil
             }
           }
     }
@@ -39,7 +39,7 @@ defmodule Bootleg.Strategies.Administration.RemoteSSHTest do
   end
 
   test "init bad", %{bad_config: config} do
-    assert_raise RuntimeError, ~r/This strategy requires "host", "user" to be configured/, fn ->
+    assert_raise RuntimeError, ~r/This strategy requires "hosts", "user" to be configured/, fn ->
       RemoteSSH.init(config)
     end
   end

--- a/test/strategies/deploy/remote_ssh_test.exs
+++ b/test/strategies/deploy/remote_ssh_test.exs
@@ -12,7 +12,7 @@ defmodule Bootleg.Strategies.Deploy.RemoteSSHTest do
                 deploy: %Bootleg.DeployConfig{
                   identity: "identity",
                   workspace: "workspace",
-                  host: "host",
+                  hosts: "host",
                   user: "user"}
                 }
     }


### PR DESCRIPTION
NOTE: after merging, all apps using bootleg must update deploy and manage configs to use `hosts` instead of `host`