### PR TITLE
Refactor app name and version out of config, into a Bootleg.Project struct

### DIFF
--- a/lib/bootleg.ex
+++ b/lib/bootleg.ex
@@ -32,4 +32,13 @@ defmodule Bootleg do
   def config do
     Config.init()
   end
+
+  @doc "Get default `%Bootleg.Project{}`"
+  @spec project :: %Bootleg.Project{}
+  def project do
+    %Bootleg.Project{
+      app_name: Mix.Project.config[:app],
+      app_version: Mix.Project.config[:version]
+    }
+  end
 end

--- a/lib/bootleg/config.ex
+++ b/lib/bootleg/config.ex
@@ -7,8 +7,6 @@ defmodule Bootleg.Config do
   the keys in the `Mix.Config`.
 
   ## Fields
-  * `app` - The name of the app being managed by `Bootleg`.
-  * `version` - The version of the app. Defaults to the `Mix.Project` version.
   * `build` - Configuration for the build tasks. This should be a `Map` in `Mix.Config`, and will
       be converted to a `Bootleg.BuildConfig` using `Bootleg.BuildConfig.init/1`.
   * `deploy` - Configuration for the deployment tasks. This should be a `Map` in `Mix.Config`, and will
@@ -39,12 +37,11 @@ defmodule Bootleg.Config do
     ```
   """
 
-  alias Mix.Project
   alias Bootleg.Config.{DeployConfig, BuildConfig, ManageConfig, ArchiveConfig}
 
   @doc false
-  @enforce_keys [:app, :version]
-  defstruct [:app, :version, :build, :deploy, :archive, :manage]
+  @enforce_keys []
+  defstruct [:build, :deploy, :archive, :manage]
 
   @doc """
   Creates a `Bootleg.Config` from the `Application` configuration (under the key `:bootleg`).
@@ -55,8 +52,6 @@ defmodule Bootleg.Config do
   @spec init([strategy]) :: %Bootleg.Config{}
   def init(options \\ []) do
     %__MODULE__{
-      app: Project.config[:app],
-      version: Project.config[:version],
       build: BuildConfig.init(default_option(options, :build)),
       deploy: DeployConfig.init(default_option(options, :deploy)),
       manage: ManageConfig.init(default_option(options, :manage)),
@@ -70,5 +65,9 @@ defmodule Bootleg.Config do
 
   def get_config(key, default \\ nil) do
     Application.get_env(:bootleg, key, default)
+  end
+
+  def strategy(%Bootleg.Config{} = config, type) do
+    get_in(config, [Access.key!(type), Access.key!(:strategy)])
   end
 end

--- a/lib/bootleg/project.ex
+++ b/lib/bootleg/project.ex
@@ -1,0 +1,5 @@
+defmodule Bootleg.Project do
+  @moduledoc ""
+  @enforce_keys [:app_name, :app_version]
+  defstruct [:app_name, :app_version]
+end

--- a/lib/mix/tasks/build.ex
+++ b/lib/mix/tasks/build.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Bootleg.Build do
   use Mix.Task
 
-  @shortdoc "Build a release"
+  alias Bootleg.Config
 
-  alias Bootleg.{Config, Config.BuildConfig, Config.ArchiveConfig}
+  @shortdoc "Build a release"
 
   @moduledoc """
   Build a release
@@ -20,17 +20,16 @@ defmodule Mix.Tasks.Bootleg.Build do
 
   @spec run(OptionParser.argv) :: :ok
   def run(_args) do
-    config = Bootleg.config
+    config = Bootleg.config()
 
-    %Config{
-      build: %BuildConfig{strategy: builder},
-      archive: %ArchiveConfig{strategy: archiver}
-    } = config
+    builder = Config.strategy(config, :build)
+    archiver = Config.strategy(config, :archive)
+    project = Bootleg.project()
 
-    {:ok, build_filename} = builder.build(config)
+    {:ok, build_filename} = builder.build(config, project)
 
     unless archiver == false do
-      archiver.archive(config, build_filename)
+      archiver.archive(config, project, build_filename)
     end
   end
 

--- a/lib/mix/tasks/deploy.ex
+++ b/lib/mix/tasks/deploy.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Bootleg.Deploy do
   use Mix.Task
 
-  @shortdoc "Deploy a release from the local cache"
+  alias Bootleg.Config
 
-  alias Bootleg.{Config, Config.DeployConfig}
+  @shortdoc "Deploy a release from the local cache"
 
   @moduledoc """
   Deploy a release
@@ -15,13 +15,12 @@ defmodule Mix.Tasks.Bootleg.Deploy do
   """
   @spec run(OptionParser.argv) :: :ok
   def run(_args) do
-    config = Bootleg.config
+    config = Bootleg.config()
 
-    %Config{
-      deploy: %DeployConfig{strategy: deployer}
-    } = config
+    strategy = Config.strategy(config, :deploy)
+    project = Bootleg.project()
 
     config
-    |> deployer.deploy()
+    |> strategy.deploy(project)
   end
 end

--- a/lib/mix/tasks/migrate.ex
+++ b/lib/mix/tasks/migrate.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Bootleg.Migrate do
   use Mix.Task
 
+  alias Bootleg.Config
+
   @shortdoc "Invokes a releases migrations."
 
   @moduledoc """
@@ -14,11 +16,14 @@ defmodule Mix.Tasks.Bootleg.Migrate do
   """
   @spec run(OptionParser.argv) :: :ok
   def run(_args) do
-    config = Bootleg.config
-    strategy = Map.get(config.manage, :strategy) || Bootleg.Strategies.Manage.Distillery
+    config = Bootleg.config()
+
+    strategy = Config.strategy(config, :manage)
+    project = Bootleg.project()
+
     config
-    |> strategy.init
-    |> strategy.migrate(config)
+    |> strategy.init(project)
+    |> strategy.migrate(config, project)
     :ok
   end
 end

--- a/lib/mix/tasks/ping.ex
+++ b/lib/mix/tasks/ping.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Bootleg.Ping do
   use Mix.Task
 
-  @shortdoc "Pings an app."
+  alias Bootleg.Config
 
-  alias Bootleg.{Config, Config.ManageConfig}
+  @shortdoc "Pings an app."
 
   @moduledoc """
   Pings a deployed release using the `Distillery` helper.
@@ -15,15 +15,14 @@ defmodule Mix.Tasks.Bootleg.Ping do
   """
   @spec run(OptionParser.argv) :: :ok
   def run(_args) do
-    config = Bootleg.config
+    config = Bootleg.config()
 
-    %Config{
-      manage: %ManageConfig{strategy: manager}
-    } = config
+    strategy = Config.strategy(config, :manage)
+    project = Bootleg.project()
 
     config
-    |> manager.init
-    |> manager.ping(config)
+    |> strategy.init(project)
+    |> strategy.ping(config, project)
     :ok
   end
 end

--- a/lib/mix/tasks/restart.ex
+++ b/lib/mix/tasks/restart.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Bootleg.Restart do
   use Mix.Task
 
-  @shortdoc "Restarts a deployed release."
-
   alias Bootleg.Config
+
+  @shortdoc "Restarts a deployed release."
 
   @moduledoc """
   Restarts a deployed release using the `Distillery` helper.
@@ -15,15 +15,14 @@ defmodule Mix.Tasks.Bootleg.Restart do
   """
   @spec run(OptionParser.argv) :: :ok
   def run(_args) do
-    config = Bootleg.config
+    config = Bootleg.config()
 
-    %Config{
-      manage: %Config.ManageConfig{strategy: manager}
-    } = config
+    strategy = Config.strategy(config, :manage)
+    project = Bootleg.project()
 
     config
-    |> manager.init
-    |> manager.restart(config)
+    |> strategy.init(project)
+    |> strategy.restart(config, project)
     :ok
   end
 end

--- a/lib/mix/tasks/start.ex
+++ b/lib/mix/tasks/start.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Bootleg.Start do
   use Mix.Task
 
-  @shortdoc "Starts a deployed release."
+  alias Bootleg.Config
 
-  alias Bootleg.{Config, Config.ManageConfig}
+  @shortdoc "Starts a deployed release."
 
   @moduledoc """
   Starts a deployed release using the `Distillery` helper.
@@ -15,15 +15,14 @@ defmodule Mix.Tasks.Bootleg.Start do
   """
   @spec run(OptionParser.argv) :: :ok
   def run(_args) do
-    config = Bootleg.config
+    config = Bootleg.config()
 
-    %Config{
-      manage: %ManageConfig{strategy: manager}
-    } = config
+    strategy = Config.strategy(config, :manage)
+    project = Bootleg.project()
 
     config
-    |> manager.init
-    |> manager.start(config)
+    |> strategy.init(project)
+    |> strategy.start(config, project)
     :ok
   end
 end

--- a/lib/mix/tasks/stop.ex
+++ b/lib/mix/tasks/stop.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Bootleg.Stop do
   use Mix.Task
 
-  @shortdoc "Stops a deployed release."
+  alias Bootleg.Config
 
-  alias Bootleg.{Config, Config.ManageConfig}
+  @shortdoc "Stops a deployed release."
 
   @moduledoc """
   Stops a deployed release using the `Distillery` helper.
@@ -15,15 +15,14 @@ defmodule Mix.Tasks.Bootleg.Stop do
   """
   @spec run(OptionParser.argv) :: :ok
   def run(_args) do
-    config = Bootleg.config
+    config = Bootleg.config()
 
-    %Config{
-      manage: %ManageConfig{strategy: manager}
-    } = config
+    strategy = Config.strategy(config, :manage)
+    project = Bootleg.project()
 
     config
-    |> manager.init
-    |> manager.stop(config)
+    |> strategy.init(project)
+    |> strategy.stop(config, project)
     :ok
   end
 end

--- a/test/strategies/archive/local_directory_test.exs
+++ b/test/strategies/archive/local_directory_test.exs
@@ -6,11 +6,12 @@ defmodule LocalDirectoryTest do
 
   setup do
     %{
+      project: %Bootleg.Project{
+        app_name: "bootleg",
+        app_version: "1.0.0"},
       filename: "build.tar.gz",
       config:
         %Bootleg.Config{
-          app: "bootleg",
-          version: "1.0.0",
           archive:
             %Bootleg.Config.ArchiveConfig{
               max_archives: 5,
@@ -19,8 +20,6 @@ defmodule LocalDirectoryTest do
         },
       bad_config:
         %Bootleg.Config{
-          app: "Funky Monkey",
-          version: "1.0.0",
           archive:
             %Bootleg.Config.ArchiveConfig{
               max_archives: 1,
@@ -30,13 +29,13 @@ defmodule LocalDirectoryTest do
     }
   end
 
-  test "init good", %{config: config, filename: filename} do
-    assert {:ok, _} = Archiver.archive(config, filename)
+  test "init good", %{config: config, filename: filename, project: project} do
+    assert {:ok, _} = Archiver.archive(config, project, filename)
   end
 
-  test "init bad", %{bad_config: config, filename: filename} do
+  test "init bad", %{bad_config: config, filename: filename, project: project} do
     assert_raise RuntimeError, ~r/This strategy requires "archive_directory" to be configured/, fn ->
-      Archiver.archive(config, filename)
+      Archiver.archive(config, project, filename)
     end
   end
 
@@ -81,41 +80,41 @@ defmodule LocalDirectoryTest do
     ]
   end
 
-  test "archive to invalid directory", %{config: config} do
+  test "archive to invalid directory", %{config: config, project: project} do
     invalid_config = %Bootleg.Config.ArchiveConfig{
       max_archives: 1,
       archive_directory: "404",
     }
     assert_raise RuntimeError, ~r/Archive directory.*couldn't be created/, fn ->
-      Archiver.archive(%{config | archive: invalid_config}, "build.tar.gz")
+      Archiver.archive(%{config | archive: invalid_config}, project, "build.tar.gz")
     end
   end
 
-  test "archive when build file doesnt exist", %{config: config} do
+  test "archive when build file doesnt exist", %{config: config, project: project} do
     assert_raise RuntimeError, ~r/file not found: 404.tar.gz/, fn ->
-      Archiver.archive(config, "404.tar.gz")
+      Archiver.archive(config, project, "404.tar.gz")
     end
   end
 
-  test "archive when folder full of releases", %{config: config} do
+  test "archive when folder full of releases", %{config: config, project: project} do
     strategy_config = %Bootleg.Config.ArchiveConfig{
       max_archives: 1,
       archive_directory: "big_release_folder",
     }
-    Archiver.archive(%{config | archive: strategy_config}, "build.tar.gz")
+    Archiver.archive(%{config | archive: strategy_config}, project, "build.tar.gz")
   end
 
-  test "archive to read-only folder", %{config: config} do
+  test "archive to read-only folder", %{config: config, project: project} do
     strategy_config = %Bootleg.Config.ArchiveConfig{
       max_archives: 1,
       archive_directory: "read_only_folder",
     }
     assert_raise RuntimeError, ~r/Error storing build/, fn ->
-      Archiver.archive(%{config | archive: strategy_config}, "build.tar.gz")
+      Archiver.archive(%{config | archive: strategy_config}, project, "build.tar.gz")
     end
   end
 
-  test "archive", %{config: config} do
-    Archiver.archive(config, "build.tar.gz")
+  test "archive", %{config: config, project: project} do
+    Archiver.archive(config, project, "build.tar.gz")
   end
 end

--- a/test/strategies/deploy/distillery_test.exs
+++ b/test/strategies/deploy/distillery_test.exs
@@ -6,9 +6,10 @@ defmodule Bootleg.Strategies.Deploy.DistilleryTest do
 
   setup do
     %{
+      project: %Bootleg.Project{
+        app_name: "bootleg",
+        app_version: "1.0.0"},
       config: %Bootleg.Config{
-                app: "bootleg",
-                version: "1.0.0",
                 deploy: %Bootleg.Config.DeployConfig{
                   identity: "identity",
                   workspace: "workspace",
@@ -18,8 +19,8 @@ defmodule Bootleg.Strategies.Deploy.DistilleryTest do
     }
   end
 
-  test "init", %{config: config} do
-    Distillery.init(config)
+  test "init", %{config: config, project: project} do
+    Distillery.init(config, project)
     assert_received({
       Bootleg.SSH,
       :init,
@@ -27,9 +28,9 @@ defmodule Bootleg.Strategies.Deploy.DistilleryTest do
     })
   end
 
-  test "deploy", %{config: config} do
+  test "deploy", %{config: config, project: project} do
     local_file = "#{File.cwd!}/releases/1.0.0.tar.gz"
-    Distillery.deploy(config)
+    Distillery.deploy(config, project)
     assert_received({
       Bootleg.SSH,
       :init,

--- a/test/strategies/manage/distillery_test.exs
+++ b/test/strategies/manage/distillery_test.exs
@@ -6,10 +6,11 @@ defmodule Bootleg.Strategies.Manage.DistilleryTest do
 
   setup do
     %{
+      project: %Bootleg.Project{
+        app_name: "bootleg",
+        app_version: "1.0.0"},
       config:
         %Bootleg.Config{
-          app: "bootleg",
-          version: "1.0.0",
           manage:
             %Bootleg.Config.ManageConfig{
               identity: "identity",
@@ -21,8 +22,6 @@ defmodule Bootleg.Strategies.Manage.DistilleryTest do
         },
       bad_config:
         %Bootleg.Config{
-          app: "Funky Monkey",
-          version: "1.0.0",
           manage:
             %Bootleg.Config.ManageConfig{
               identity: nil,
@@ -32,8 +31,6 @@ defmodule Bootleg.Strategies.Manage.DistilleryTest do
         },
       bad_migrate_config:
         %Bootleg.Config{
-          app: "bootleg",
-          version: "1.0.0",
           manage:
             %Bootleg.Config.ManageConfig{
               identity: "identity",
@@ -44,8 +41,6 @@ defmodule Bootleg.Strategies.Manage.DistilleryTest do
         },
       migration_function_config:
         %Bootleg.Config{
-          app: "bootleg",
-          version: "1.0.0",
           manage:
             %Bootleg.Config.ManageConfig{
               identity: "identity",
@@ -59,50 +54,50 @@ defmodule Bootleg.Strategies.Manage.DistilleryTest do
     }
   end
 
-  test "init good", %{config: config} do
-    Distillery.init(config)
+  test "init good", %{config: config, project: project} do
+    Distillery.init(config, project)
     assert_received({Bootleg.SSH, :init, ["host", "user", [identity: "identity", workspace: "."]]})
   end
 
-  test "init bad", %{bad_config: config} do
+  test "init bad", %{bad_config: config, project: project} do
     assert_raise RuntimeError, ~r/This strategy requires "hosts", "user" to be configured/, fn ->
-      Distillery.init(config)
+      Distillery.init(config, project)
     end
   end
 
-  test "start", %{config: config} do
-    Distillery.start(:conn, config)
+  test "start", %{config: config, project: project} do
+    Distillery.start(:conn, config, project)
     assert_received({Bootleg.SSH, :"run!", [:conn, "bin/bootleg start"]})
   end
 
-  test "stop", %{config: config} do
-    Distillery.stop(:conn, config)
+  test "stop", %{config: config, project: project} do
+    Distillery.stop(:conn, config, project)
     assert_received({Bootleg.SSH, :"run!", [:conn, "bin/bootleg stop"]})
   end
 
-  test "restart", %{config: config} do
-    Distillery.restart(:conn, config)
+  test "restart", %{config: config, project: project} do
+    Distillery.restart(:conn, config, project)
     assert_received({Bootleg.SSH, :"run!", [:conn, "bin/bootleg restart"]})
   end
 
-  test "ping", %{config: config} do
-    Distillery.ping(:conn, config)
+  test "ping", %{config: config, project: project} do
+    Distillery.ping(:conn, config, project)
     assert_received({Bootleg.SSH, :"run!", [:conn, "bin/bootleg ping"]})
   end
 
-  test "migrate with 'migration_function' uses the configured function", %{migration_function_config: config} do
+  test "migrate with 'migration_function' uses the configured function", %{migration_function_config: config, project: project} do
     IO.puts config.manage.migration_module
-    Distillery.migrate(:conn, config)
+    Distillery.migrate(:conn, config, project)
     assert_received({Bootleg.SSH, :"run!", [:conn, "bin/bootleg rpcterms Elixir.MyApp.Module a_function 'bootleg.'"]})
   end
 
-  test "migrate without 'migration_function' uses 'migrate/0'", %{config: config} do
+  test "migrate without 'migration_function' uses 'migrate/0'", %{config: config, project: project} do
     IO.puts config.manage.migration_module
-    Distillery.migrate(:conn, config)
+    Distillery.migrate(:conn, config, project)
     assert_received({Bootleg.SSH, :"run!", [:conn, "bin/bootleg rpcterms Elixir.MyApp.Module migrate 'bootleg.'"]})
   end
 
-  test "migrate required configuration", %{bad_migrate_config: config} do
-    assert catch_error(Distillery.migrate(:conn, config)) == %RuntimeError{message: "Error: This strategy requires \"migration_module\" to be configured"}
+  test "migrate required configuration", %{bad_migrate_config: config, project: project} do
+    assert catch_error(Distillery.migrate(:conn, config, project)) == %RuntimeError{message: "Error: This strategy requires \"migration_module\" to be configured"}
   end
 end


### PR DESCRIPTION
This also removes the `APP=` environment variable, which I think was only an artifact from edeliver