### PR TITLE
Switch over to upstream SSHKit v0.0.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Bootleg.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:sshkit, github: "labzero/sshkit.ex"},
+      {:sshkit, "0.0.3"},
       {:ssh_client_key_api, "0.0.1"},
       {:credo, "~> 0.7", only: [:dev, :test]},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "mock": {:hex, :mock, "0.2.1", "bfdba786903e77f9c18772dee472d020ceb8ef000783e737725a4c8f54ad28ec", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "ssh_client_key_api": {:hex, :ssh_client_key_api, "0.0.1", "521076c1c468275b351cb2c28dd185ba76a07afff7706805add1e0892f0b64a9", [:mix], [], "hexpm"},
-  "sshkit": {:git, "https://github.com/labzero/sshkit.ex.git", "8cc294b37f83d93c2b6838bf0ce9dff854162d58", []},
+  "sshkit": {:hex, :sshkit, "0.0.3", "b0d7c3e0a5caed69304ccbc1c97ab0b1fe82a26f0d21ba2a26b52868f834ab5a", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "temp": {:hex, :temp, "0.4.3", "b641c3ce46094839bff110fdb64162536d640d9d47ca2c37add9104a2fa3bd81", [:mix], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], [], "hexpm"}}


### PR DESCRIPTION
Now that v0.0.3 has been released which includes our context SCP work we can switch over to the official published hex package