### PR TITLE
Silently stop any running nodes during `update`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ Alternatively the above commands can be rolled into one with:
 mix bootleg.update production
 ```
 
+Note that `bootleg.update` will stop any running nodes and then perform a cold start. The stop is performed with
+the task `stop_silent`, which differs from `stop` in that it does not fail if the node is already stopped.
+
 ## Admin Commands
 
 Bootleg has a set of commands to check up on your running nodes:

--- a/lib/bootleg/tasks/update.exs
+++ b/lib/bootleg/tasks/update.exs
@@ -3,5 +3,13 @@ use Bootleg.Config
 task :update do
   invoke :build
   invoke :deploy
+  invoke :stop_silent
   invoke :start
+end
+
+task :stop_silent do
+  nodetool = "bin/#{Config.app}"
+  remote :app do
+    "#{nodetool} describe && (#{nodetool} stop || true)"
+  end
 end

--- a/lib/mix/tasks/update.ex
+++ b/lib/mix/tasks/update.ex
@@ -4,7 +4,11 @@ defmodule Mix.Tasks.Bootleg.Update do
   @shortdoc "Build, deploy, and start a release all in one command."
 
   @moduledoc """
-  Update a release
+  Update a release.
+
+  Note that this will stop any running nodes and then perform a cold start. The stop is performed with
+  the task `stop_silent`, which differs from `stop` in that it does not require a node to already be
+  running.
 
   # Usage:
 

--- a/test/bootleg_functional_test.exs
+++ b/test/bootleg_functional_test.exs
@@ -60,6 +60,32 @@ defmodule Bootleg.FunctionalTest do
 
         invoke :update
       end), ~r/build_me started/)
+
+      capture_io(fn ->
+        # credo:disable-for-next-line Credo.Check.Consistency.MultiAliasImportRequireUse
+        use Bootleg.Config
+
+        remote :app do
+          "wait-for-app build_me"
+        end
+
+        [{:ok, [stdout: pid_1], 0, _}, {:ok, [stdout: pid_2], 0, _}] = remote :app do
+          "bin/build_me pid"
+        end
+
+        invoke :update
+
+        remote :app do
+          "wait-for-app build_me"
+        end
+
+        [{:ok, [stdout: new_pid_1], 0, _}, {:ok, [stdout: new_pid_2], 0, _}] = remote :app do
+          "bin/build_me pid"
+        end
+
+        assert pid_1 != new_pid_1
+        assert pid_2 != new_pid_2
+      end)
     end)
   end
 

--- a/test/support/docker/fixtures/bin/launch-app
+++ b/test/support/docker/fixtures/bin/launch-app
@@ -3,11 +3,4 @@
 set -e
 
 bin/$1 start
-TRIES=0
-while [[ "`bin/$1 ping`" != "pong" ]]; do
-  sleep 0.5
-  TRIES=$(($TRIES + 1))
-  if [[ $TRIES -gt 9 ]]; then
-    exit 1
-  fi
-done
+wait-for-app $1

--- a/test/support/docker/fixtures/bin/wait-for-app
+++ b/test/support/docker/fixtures/bin/wait-for-app
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+TRIES=0
+while [[ "`bin/$1 ping`" != "pong" ]]; do
+  sleep 0.5
+  TRIES=$(($TRIES + 1))
+  if [[ $TRIES -gt 9 ]]; then
+    exit 1
+  fi
+done


### PR DESCRIPTION
Fix #143 