### PR TITLE
Verify app and version are set (umbrella projects)

### DIFF
--- a/lib/bootleg/config.ex
+++ b/lib/bootleg/config.ex
@@ -488,13 +488,29 @@ defmodule Bootleg.Config do
   @doc false
   @spec app() :: any
   def app do
-    get_config(:app, Project.config[:app])
+    :config
+    |> Bootleg.Config.Agent.get()
+    |> Keyword.get_lazy(:app, fn -> cache_project_config(:app) end)
   end
 
   @doc false
   @spec version() :: any
   def version do
-    get_config(:version, Project.config[:version])
+    :config
+    |> Bootleg.Config.Agent.get()
+    |> Keyword.get_lazy(:version, fn -> cache_project_config(:version) end)
+  end
+
+  @doc false
+  @spec cache_project_config(atom) :: any
+  def cache_project_config(prop) do
+    unless Project.umbrella? do
+      val = Project.config[prop]
+      Bootleg.Config.Agent.merge(:config, prop, val)
+      val
+    else
+      nil
+    end
   end
 
   @doc false

--- a/lib/bootleg/tasks/build.exs
+++ b/lib/bootleg/tasks/build.exs
@@ -1,9 +1,21 @@
 alias Bootleg.{UI, Config}
 use Bootleg.Config
 
+task :verify_config do
+  if Config.app() == nil || Config.version() == nil do
+    raise "Error: app or version to deploy is not set.\n"
+     <> "Usually these are automatically picked up from Mix.Project.\n"
+     <> "If this is an umbrella app, you must set these in your deploy.exs, e.g.:\n"
+     <> "# config(:app, :myapp)\n"
+     <> "# config(:version, \"0.0.1\")"
+  end
+end
+
 task :build do
   Bootleg.Strategies.Build.Distillery.build()
 end
+
+before_task :build, :verify_config
 
 task :generate_release do
   UI.info "Generating release"

--- a/test/bootleg_functional_test.exs
+++ b/test/bootleg_functional_test.exs
@@ -142,7 +142,8 @@ defmodule Bootleg.FunctionalTest do
     end)
 
     assert {_, 0} = System.cmd("mix", ["deps.get"], [env: shell_env, cd: location])
-    assert {output, 1} = System.cmd("mix", ["bootleg.invoke", "build"], [stderr_to_stdout: true, env: shell_env, cd: location])
+    assert {output, 1} = System.cmd("mix", ["bootleg.invoke", "build"],
+      [stderr_to_stdout: true, env: shell_env, cd: location])
     assert String.match?(output, ~r/app or version to deploy is not set./i)
     assert String.match?(output, ~r/If this is an umbrella app/m)
 

--- a/test/bootleg_functional_test.exs
+++ b/test/bootleg_functional_test.exs
@@ -117,7 +117,7 @@ defmodule Bootleg.FunctionalTest do
   end
 
   @tag boot: 0
-  test "init" do
+  test "init normal project" do
     shell_env = [{"BOOTLEG_PATH", File.cwd!}]
     location = Fixtures.inflate_project(:n00b)
     Enum.each(["deps.get", "bootleg.init"], fn cmd ->
@@ -126,4 +126,38 @@ defmodule Bootleg.FunctionalTest do
     assert File.regular?(Path.join([location, "config", "deploy.exs"]))
   end
 
+  @tag boot: 1, timeout: 60_000
+  test "init umbrella project", %{hosts: hosts} do
+    shell_env = [{"BOOTLEG_PATH", File.cwd!}]
+    build_host = List.first(hosts)
+    location = Fixtures.inflate_project(:umbra)
+
+    File.open!(Path.join([location, "config", "deploy.exs"]), [:write], fn file ->
+      IO.write(file, """
+        use Bootleg.Config
+
+        role :build, "#{build_host.ip}", port: #{build_host.port}, user: "#{build_host.user}",
+          silently_accept_hosts: true, workspace: "workspace", identity: "#{build_host.private_key_path}"
+      """)
+    end)
+
+    assert {_, 0} = System.cmd("mix", ["deps.get"], [env: shell_env, cd: location])
+    assert {output, 1} = System.cmd("mix", ["bootleg.invoke", "build"], [stderr_to_stdout: true, env: shell_env, cd: location])
+    assert String.match?(output, ~r/app or version to deploy is not set./i)
+    assert String.match?(output, ~r/If this is an umbrella app/m)
+
+    File.open!(Path.join([location, "config", "deploy.exs"]), [:append], fn file ->
+      IO.write(file, """
+        config :app, :foo
+        config :version, "0.0.1"
+
+        task :build do
+          IO.puts "Build done"
+        end
+      """)
+    end)
+
+    assert {output, 0} = System.cmd("mix", ["bootleg.invoke", "build"], [env: shell_env, cd: location])
+    assert String.match?(output, ~r/Build done/)
+  end
 end

--- a/test/fixtures/umbra/.gitignore
+++ b/test/fixtures/umbra/.gitignore
@@ -1,0 +1,20 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/test/fixtures/umbra/README.md
+++ b/test/fixtures/umbra/README.md
@@ -1,0 +1,4 @@
+# Umbra
+
+**TODO: Add description**
+

--- a/test/fixtures/umbra/config/config.exs
+++ b/test/fixtures/umbra/config/config.exs
@@ -1,0 +1,17 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# By default, the umbrella project as well as each child
+# application will require this configuration file, ensuring
+# they all use the same configuration. While one could
+# configure all applications here, we prefer to delegate
+# back to each application for organization purposes.
+import_config "../apps/*/config/config.exs"
+
+# Sample configuration (overrides the imported configuration above):
+#
+#     config :logger, :console,
+#       level: :info,
+#       format: "$date $time [$level] $metadata$message\n",
+#       metadata: [:user_id]

--- a/test/fixtures/umbra/mix.exs
+++ b/test/fixtures/umbra/mix.exs
@@ -1,0 +1,28 @@
+defmodule Umbra.Mixfile do
+  use Mix.Project
+
+  def project do
+    [apps_path: "apps",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps()]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:my_dep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options.
+  #
+  # Dependencies listed here are available only for this project
+  # and cannot be accessed from applications inside the apps folder
+  defp deps do
+    [
+      {:bootleg, ">= 0.0.0", path: System.get_env("BOOTLEG_PATH"), runtime: false}
+    ]
+  end
+end


### PR DESCRIPTION
Closes #162 
* Only call `Mix.Project.config/0` when user hasn't set, or when we haven't determined a value previously
* Ignore `Mix.Project.config/0` values when in an umbrella project
* Use an overridable task to ensure app and version are set
