### PR TITLE
Add custom working directory support to `remote/3`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,14 @@ remote :app do
 end
 
 # filtering - only runs on app hosts with an option of primary set to true
-remote :app, primary: true do
+remote :app, filter: [primary: true] do
   "mix ecto.migrate"
+end
+
+# change working directory - creates a file `/tmp/foo`, regardless of the role
+# workspace configuration
+remote :app, cd: "/tmp" do
+  "touch ./foo"
 end
 ```
 

--- a/lib/bootleg/config.ex
+++ b/lib/bootleg/config.ex
@@ -338,18 +338,18 @@ defmodule Bootleg.Config do
   @doc """
   Executes commands on all remote hosts within a role.
 
-  This is equivalent to calling `remote/3` with a `filter` of `[]`.
+  This is equivalent to calling `remote/3` with an `options` of `[]`.
   """
   defmacro remote(role, lines) do
     quote do: remote(unquote(role), [], unquote(lines))
   end
 
-  defmacro remote(role, filter, do: {:__block__, _, lines}) do
-    quote do: remote(unquote(role), unquote(filter), unquote(lines))
+  defmacro remote(role, options, do: {:__block__, _, lines}) do
+    quote do: remote(unquote(role), unquote(options), unquote(lines))
   end
 
-  defmacro remote(role, filter, do: lines) do
-    quote do: remote(unquote(role), unquote(filter), unquote(lines))
+  defmacro remote(role, options, do: lines) do
+    quote do: remote(unquote(role), unquote(options), unquote(lines))
   end
 
   @doc """
@@ -363,9 +363,16 @@ defmodule Bootleg.Config do
   used as a command. Each command will be simulataneously executed on all hosts in the role. Once
   all hosts have finished executing the command, the next command in the list will be sent.
 
-  `filter` is an optional `Keyword` list of host options to filter with. Any host whose options match
+  `options` is an optional `Keyword` list of options to customize the remote invocation. Currently two
+  keys are supported:
+  
+    * `filter` takes a `Keyword` list of host options to filter with. Any host whose options match
   the filter will be included in the remote execution. A host matches if it has all of the filtering
   options defined and the values match (via `==/2`) the filter.
+    * `cd` changes the working directory of the remote shell prior to executing the remote
+    commands. The options takes either an absolute or relative path, with relative paths being
+    defined relative to the workspace configured for the role, or the default working directory
+    of the shell if no workspace is defined.
 
   `role` can be a single role, a list of roles, or the special role `:all` (all roles). If the same host
   exists in multiple roles, the commands will be run once for each role where the host shows up. In the
@@ -394,19 +401,24 @@ defmodule Bootleg.Config do
 
   # only runs on `host1.example.com`
   role :build, "host2.example.com"
-  role :build, "host1.example.com", primary: true, another_attr: :cat
+  role :build, "host1.example.com", filter: [primary: true, another_attr: :cat]
 
-  remote :build, primary: true do
+  remote :build, filter: [primary: true] do
+    "hostname"
+  end
+
+  # runs on `host1.example.com` inside the `tmp` directory found in the workspace
+  remote :build, filter: [primary: true], cd: "tmp/" do
     "hostname"
   end
   ```
   """
-  defmacro remote(role, filter, lines) do
+  defmacro remote(role, options, lines) do
     roles = unpack_role(role)
     quote bind_quoted: binding() do
       Enum.reduce(roles, [], fn role, outputs ->
         role
-        |> SSH.init([], filter)
+        |> SSH.init([cd: options[:cd]], Keyword.get(options, :filter, []))
         |> SSH.run!(lines)
         |> SSH.merge_run_results(outputs)
       end)

--- a/lib/bootleg/ssh.ex
+++ b/lib/bootleg/ssh.ex
@@ -37,6 +37,7 @@ defmodule Bootleg.SSH do
   def init(hosts, options) do
     workspace = Keyword.get(options, :workspace, ".")
     create_workspace = Keyword.get(options, :create_workspace, true)
+    working_directory = Keyword.get(options, :cd)
     UI.puts "Creating remote context at '#{workspace}'"
 
     :ssh.start()
@@ -46,6 +47,7 @@ defmodule Bootleg.SSH do
     |> Enum.map(&ssh_host_options/1)
     |> SSHKit.context()
     |> validate_workspace(workspace, create_workspace)
+    |> working_directory(working_directory)
   end
 
   def ssh_host_options(%Host{} = host) do
@@ -82,6 +84,16 @@ defmodule Bootleg.SSH do
   defp validate_workspace(context, workspace, true) do
     run!(context, "mkdir -p #{workspace}")
     SSHKit.path context, workspace
+  end
+
+  defp working_directory(context, path) when path == "." or path == false or is_nil(path) do
+    context
+  end
+  defp working_directory(context, path) do
+    case Path.type(path) do
+      :absolute -> %Context{context | path: path}
+      _ -> %Context{context | path: Path.join(context.path, path)}
+    end
   end
 
   defp capture(message, {buffer, status} = state, host) do

--- a/test/bootleg/config_functional_test.exs
+++ b/test/bootleg/config_functional_test.exs
@@ -136,19 +136,22 @@ defmodule Bootleg.ConfigFunctionalTest do
   end
 
   @tag boot: 3
-  test "remote/3 filtering" do
+  test "remote/3 options" do
     capture_io(fn ->
       use Bootleg.Config
 
-      assert [{:ok, out_0, 0, _}] = remote :build, [foo: 0], "hostname"
-      assert [{:ok, out_1, 0, _}] = remote :build, [foo: 1], do: "hostname"
+      assert [{:ok, out_0, 0, _}] = remote :build, [filter: [foo: 0]], "hostname"
+      assert [{:ok, out_1, 0, _}] = remote :build, [filter: [foo: 1]], do: "hostname"
       assert out_1 != out_0
 
-      assert [] = remote :build, [foo: :bar], "hostname"
-      assert [{:ok, out_all, 0, _}] = remote :all, [foo: :bar], "hostname"
+      assert [] = remote :build, [filter: [foo: :bar]], "hostname"
+      assert [{:ok, out_all, 0, _}] = remote :all, [filter: [foo: :bar]], "hostname"
       assert out_1 != out_0 != out_all
 
-      remote :all, [foo: :bar] do "hostname" end
+      remote :all, filter: [foo: :bar] do "hostname" end
+
+      [{:ok, [stdout: "/tmp\n"], 0, _}] = remote :app, cd: "/tmp" do "pwd" end
+      [{:ok, [stdout: "/home\n"], 0, _}] = remote :app, cd: "../.." do "pwd" end
     end)
   end
 


### PR DESCRIPTION
Resolves #164 and closes #170.

Note: introduces a breaking change in how the `remote/3` API works.