### PR TITLE
Add support for different length result lists to `SSH.merge_run_results/2`.

### DIFF
--- a/lib/bootleg/ssh.ex
+++ b/lib/bootleg/ssh.ex
@@ -215,6 +215,13 @@ defmodule Bootleg.SSH do
     orig
   end
   def merge_run_results(new, orig) when is_list(orig) do
+    delta = length(new) - length(orig)
+    entries = List.duplicate([], abs(delta))
+    {new, orig} = if delta > 0 do
+        {new, orig ++ entries}
+      else
+        {new ++ entries, orig}
+      end
     new
     |> Enum.zip(orig)
     |> Enum.map(fn {n, o} ->

--- a/test/bootleg/ssh_test.exs
+++ b/test/bootleg/ssh_test.exs
@@ -53,6 +53,8 @@ defmodule Bootleg.SSHTest do
     assert [1, 2] = SSH.merge_run_results([1, 2], [])
     assert [[1, 2]] = SSH.merge_run_results([[1, 2]], [])
     assert [[1, 2]] = SSH.merge_run_results([], [[1, 2]])
+    assert [[2, 1], [4]] = SSH.merge_run_results([1], [2, 4])
+    assert [[1, 2], [4]] = SSH.merge_run_results([2, 4], [1])
   end
 
   test "supported_options/0" do


### PR DESCRIPTION
Fixes #189.