### PR TITLE
Add back in generate_release tasks

### DIFF
--- a/docs/reference/workflow.md
+++ b/docs/reference/workflow.md
@@ -16,6 +16,7 @@
         - `push_remote`
         - `reset_remote`
 - `compile`
+- `remote_generate_release`
 - `release_workspace set?`
     - `yes`
         - `copy_build_release`
@@ -28,6 +29,7 @@
 - `local_verify_config`
 - `local_build`
 - `local_compile`
+- `local_generate_release`
 - `local_copy_release`
 
 ### Docker Builds
@@ -36,6 +38,7 @@
 - `docker_verify_config`
 - `docker_build`
 - `docker_compile`
+- `docker_generate_release`
 - `docker_copy_release`
 
 ## Deployment Workflow

--- a/lib/bootleg/tasks/build/remote.exs
+++ b/lib/bootleg/tasks/build/remote.exs
@@ -14,6 +14,7 @@ task :remote_build do
   invoke(:clean)
   invoke(:remote_scm_update)
   invoke(:compile)
+  invoke(:generate_release)
 
   if build_role.options[:release_workspace] do
     invoke(:copy_build_release)
@@ -42,11 +43,6 @@ task :compile do
   mix_env = config({:mix_env, "prod"})
   source_path = config({:ex_path, ""})
 
-  release_args =
-    {:release_args, ["--quiet"]}
-    |> config()
-    |> Enum.join(" ")
-
   UI.info("Building on remote server with mix env #{mix_env}...")
 
   remote :build, cd: source_path do
@@ -54,6 +50,21 @@ task :compile do
     "MIX_ENV=#{mix_env} mix local.hex --if-missing --force"
     "MIX_ENV=#{mix_env} mix deps.get --only=#{mix_env}"
     "MIX_ENV=#{mix_env} mix do clean, compile --force"
+  end
+end
+
+task :generate_release do
+  mix_env = config({:mix_env, "prod"})
+  source_path = config({:ex_path, ""})
+
+  release_args =
+    {:release_args, ["--quiet"]}
+    |> config()
+    |> Enum.join(" ")
+
+  UI.info("Generating release...")
+
+  remote :build, cd: source_path do
     "MIX_ENV=#{mix_env} mix release #{release_args}"
   end
 end

--- a/lib/bootleg/tasks/build/remote.exs
+++ b/lib/bootleg/tasks/build/remote.exs
@@ -54,7 +54,6 @@ task :compile do
 end
 
 task :generate_release do
-  UI.warn(":generate_release is deprecated, please use :remote_generate_release instead")
   invoke(:remote_generate_release)
 end
 

--- a/lib/bootleg/tasks/build/remote.exs
+++ b/lib/bootleg/tasks/build/remote.exs
@@ -14,7 +14,7 @@ task :remote_build do
   invoke(:clean)
   invoke(:remote_scm_update)
   invoke(:compile)
-  invoke(:generate_release)
+  invoke(:remote_generate_release)
 
   if build_role.options[:release_workspace] do
     invoke(:copy_build_release)
@@ -54,6 +54,11 @@ task :compile do
 end
 
 task :generate_release do
+  UI.warn(":generate_release is deprecated, please use :remote_generate_release instead")
+  invoke(:remote_generate_release)
+end
+
+task :remote_generate_release do
   mix_env = config({:mix_env, "prod"})
   source_path = config({:ex_path, ""})
 


### PR DESCRIPTION
Closes #274 

Task names:
- remote builds: `:remote_generate_release` (`:generate_release` is still available and invokes it)
- local builds: `:local_generate_release`
- docker builds: `:docker_generate_release`