### PR TITLE
Show available tasks with “mix bootleg”

### DIFF
--- a/lib/mix/tasks/bootleg.ex
+++ b/lib/mix/tasks/bootleg.ex
@@ -1,9 +1,21 @@
 defmodule Mix.Tasks.Bootleg do
-  use Bootleg.MixTask
+  use Mix.Task
+  alias Mix.Tasks.Help
 
-  @shortdoc "Build and deploy releases"
+  @shortdoc "Prints Bootleg help information"
 
   @moduledoc """
-    Build and deploy Elixir applications
+  Prints Bootleg tasks and their information.
+
+      mix bootleg
   """
+
+  @doc false
+  def run(_args) do
+    Application.ensure_all_started(:bootleg)
+    Mix.shell().info("Bootleg v#{Application.spec(:bootleg, :vsn)}")
+    Mix.shell().info("Simple deployment and server automation for Elixir.")
+    Mix.shell().info("\nAvailable tasks:\n")
+    Help.run(["--search", "bootleg."])
+  end
 end

--- a/test/mix/tasks/bootleg_test.exs
+++ b/test/mix/tasks/bootleg_test.exs
@@ -1,0 +1,13 @@
+defmodule Mix.Tasks.BootlegTest do
+  use ExUnit.Case
+  alias Mix.Tasks.Bootleg
+
+  test "provide a list of available bootleg mix tasks" do
+    Bootleg.run([])
+    assert_received {:mix_shell, :info, ["Bootleg v" <> _]}
+    assert_received {:mix_shell, :info, ["mix bootleg.build" <> _]}
+    assert_received {:mix_shell, :info, ["mix bootleg.init" <> _]}
+    assert_received {:mix_shell, :info, ["mix bootleg.invoke" <> _]}
+    assert_received {:mix_shell, :info, ["mix bootleg.update" <> _]}
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -24,5 +24,9 @@ unless skip_functional_tests do
   System.put_env("BOOTLEG_DOCKER_IMAGE", image_name)
 end
 
+# For tasks testing
+Mix.start()
+Mix.shell(Mix.Shell.Process)
+
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()


### PR DESCRIPTION
```bash
$ mix bootleg
==> bootleg
Compiling 10 files (.ex)
==> sample
Bootleg v0.10.0
Simple deployment and server automation for Elixir.

Available tasks:

mix bootleg.build   # Build a release
mix bootleg.deploy  # Deploy a release from the local cache
mix bootleg.init    # Initializes a project for use with Bootleg
mix bootleg.invoke  # Calls an arbitrary Bootleg task
mix bootleg.ping    # Pings an app.
mix bootleg.restart # Restarts a deployed release.
mix bootleg.start   # Starts a deployed release.
mix bootleg.stop    # Stops a deployed release.
mix bootleg.update  # Build, deploy, and start a release all in one command.
```