### PR TITLE
Compatibility with Distillery 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ add additional support.
 
 ```
 def deps do
-  [{:distillery, "~> 2.0", runtime: false},
+  [{:distillery, "~> 2.1", runtime: false},
    {:bootleg, "~> 0.11", runtime: false}]
 end
 ```

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -22,7 +22,7 @@ $ mix deps.get
 !!! tip
     If upgrading from an earlier version of Distillery, you may want to generate a new `rel/config.exs` with which to compare your existing configuration.
 
-If you do not have a `rel/config.exs` file, please follow the [Distillery guide](https://hexdocs.pm/distillery/introduction/installation.html) to create one. Generally this consists of running `mix release.init` and reviewing the resulting file.
+If you do not have a `rel/config.exs` file, please follow the [Distillery guide](https://hexdocs.pm/distillery/introduction/installation.html) to create one. Generally this consists of running `mix distillery.init` and reviewing the resulting file.
 
 ## Set-up Bootleg
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -6,7 +6,7 @@ Add to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:distillery, "~> 2.0", runtime: false},
+  [{:distillery, "~> 2.1", runtime: false},
    {:bootleg, "~> 0.11", runtime: false}]
 end
 ```

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -9,7 +9,7 @@
 | `env`        | Sets or overrides the Bootleg environment.                                                              | `#!elixir "production"`       |
 | `mix_env` | Overrides the Mix environment. | `#!elixir "prod"` |
 | `build_type` | Specifies which build strategy to use, from: `#!elixir :local`, `#!elixir :docker`, `#!elixir :remote`. | `#!elixir :remote` |
-| `release_args` | List of arguments to pass to `mix release` | `#!elixir ["--quiet"]` |
+| `release_args` | List of arguments to pass to `mix distillery.release` | `#!elixir ["--quiet"]` |
 
 ### Miscellaneous
 

--- a/docs/reference/phoenix.md
+++ b/docs/reference/phoenix.md
@@ -9,7 +9,7 @@ You may use the [bootleg_phoenix](https://github.com/labzero/bootleg_phoenix) pa
 !!! example "mix.exs"
     ```elixir hl_lines="4"
     def deps do
-      [{:distillery, "~> 2.0", runtime: false},
+      [{:distillery, "~> 2.1", runtime: false},
        {:bootleg, "~> 0.8", runtime: false},
        {:bootleg_phoenix, "~> 0.2", runtime: false}]
     end

--- a/lib/bootleg/tasks/build/docker.exs
+++ b/lib/bootleg/tasks/build/docker.exs
@@ -67,7 +67,7 @@ task :docker_generate_release do
   UI.info("Generating release...")
 
   commands = [
-    ["mix", ["release"] ++ release_args]
+    ["mix", ["distillery.release"] ++ release_args]
   ]
 
   docker_args =

--- a/lib/bootleg/tasks/build/local.exs
+++ b/lib/bootleg/tasks/build/local.exs
@@ -36,7 +36,7 @@ task :local_generate_release do
   UI.info("Generating release...")
 
   commands = [
-    ["mix", ["release"] ++ release_args]
+    ["mix", ["distillery.release"] ++ release_args]
   ]
 
   File.cd!(source_path, fn ->

--- a/lib/bootleg/tasks/build/remote.exs
+++ b/lib/bootleg/tasks/build/remote.exs
@@ -69,7 +69,7 @@ task :remote_generate_release do
   UI.info("Generating release...")
 
   remote :build, cd: source_path do
-    "MIX_ENV=#{mix_env} mix release #{release_args}"
+    "MIX_ENV=#{mix_env} mix distillery.release #{release_args}"
   end
 end
 

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,8 @@ defmodule Bootleg.Mixfile do
       {:excoveralls, "~> 0.10", only: [:test]},
       {:mock, "~> 0.3.3", only: [:test]},
       {:junit_formatter, "~> 2.0", only: [:test]},
-      {:temp, "~> 0.4.3", only: [:test]}
+      {:temp, "~> 0.4.3", only: [:test]},
+      {:distillery, ">= 2.1.0", runtime: false}
     ]
   end
 

--- a/test/fixtures/bootstraps/mix.exs
+++ b/test/fixtures/bootstraps/mix.exs
@@ -31,7 +31,7 @@ defmodule Bootstraps.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:distillery, "~> 2.1", runtime: false},
+      {:distillery, "~> 2.1.0", runtime: false},
       {:bootleg, ">= 0.0.0", path: System.get_env("BOOTLEG_PATH"), runtime: false}
     ]
   end

--- a/test/fixtures/bootstraps/mix.exs
+++ b/test/fixtures/bootstraps/mix.exs
@@ -31,7 +31,7 @@ defmodule Bootstraps.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:distillery, "~> 2.0.0", runtime: false},
+      {:distillery, "~> 2.1", runtime: false},
       {:bootleg, ">= 0.0.0", path: System.get_env("BOOTLEG_PATH"), runtime: false}
     ]
   end

--- a/test/fixtures/bootstraps/rel/config.exs
+++ b/test/fixtures/bootstraps/rel/config.exs
@@ -7,7 +7,7 @@
 |> Path.wildcard()
 |> Enum.map(&Code.eval_file(&1))
 
-use Mix.Releases.Config,
+use Distillery.Releases.Config,
   # This sets the default release built by `mix distillery.release`
   default_release: :default,
   # This sets the default environment used by `mix distillery.release`

--- a/test/fixtures/bootstraps/rel/config.exs
+++ b/test/fixtures/bootstraps/rel/config.exs
@@ -8,9 +8,9 @@
 |> Enum.map(&Code.eval_file(&1))
 
 use Mix.Releases.Config,
-  # This sets the default release built by `mix release`
+  # This sets the default release built by `mix distillery.release`
   default_release: :default,
-  # This sets the default environment used by `mix release`
+  # This sets the default environment used by `mix distillery.release`
   default_environment: Mix.env()
 
 # For a full list of config options for both releases
@@ -33,10 +33,9 @@ environment :prod do
   set(cookie: :"l0Qe@8dHJa1LODI)k3WwFCG`@%BR|MJzS5UNH_f8xIN`u1(]i1G|{*6OZqt1?C_X")
 end
 
-# You may define one or more releases in this file.
-# If you have not set a default release, or selected one
-# when running `mix release`, the first release in the file
-# will be used by default
+# You may define one or more releases in this file. If you have not set a
+# default release, or selected one when running `mix distillery.release`,
+# the first release in the file will be used by default
 
 release :bootstraps do
   set(version: current_version(:bootstraps))

--- a/test/fixtures/build_me/mix.exs
+++ b/test/fixtures/build_me/mix.exs
@@ -30,6 +30,6 @@ defmodule BuildMe.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:distillery, "~> 2.0.0", runtime: false}]
+    [{:distillery, "~> 2.1.0", runtime: false}]
   end
 end

--- a/test/fixtures/build_me/rel/config.exs
+++ b/test/fixtures/build_me/rel/config.exs
@@ -9,9 +9,9 @@
 |> Enum.map(&Code.eval_file(&1))
 
 use Mix.Releases.Config,
-  # This sets the default release built by `mix release`
+  # This sets the default release built by `mix distillery.release`
   default_release: :default,
-  # This sets the default environment used by `mix release`
+  # This sets the default environment used by `mix distillery.release`
   default_environment: Mix.env()
 
 # For a full list of config options for both releases
@@ -34,10 +34,9 @@ environment :prod do
   set(cookie: :"[7o)DJ]AnI4;eNDXgRk.%3$yjTi/J<r5EG%v>Y{7ACZZ>b7kl(,OL3.w;MsPyjk3")
 end
 
-# You may define one or more releases in this file.
-# If you have not set a default release, or selected one
-# when running `mix release`, the first release in the file
-# will be used by default
+# You may define one or more releases in this file. If you have not set a
+# default release, or selected one when running `mix distillery.release`,
+# the first release in the file will be used by default
 
 release :build_me do
   set(version: current_version(:build_me))

--- a/test/fixtures/build_me/rel/config.exs
+++ b/test/fixtures/build_me/rel/config.exs
@@ -8,7 +8,7 @@
 |> Path.wildcard()
 |> Enum.map(&Code.eval_file(&1))
 
-use Mix.Releases.Config,
+use Distillery.Releases.Config,
   # This sets the default release built by `mix distillery.release`
   default_release: :default,
   # This sets the default environment used by `mix distillery.release`

--- a/test/fixtures/n00b/mix.exs
+++ b/test/fixtures/n00b/mix.exs
@@ -31,7 +31,7 @@ defmodule N00b.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:distillery, "~> 2.0.0", runtime: false},
+      {:distillery, "~> 2.1.0", runtime: false},
       {:bootleg, ">= 0.0.0", path: System.get_env("BOOTLEG_PATH"), runtime: false}
     ]
   end

--- a/test/fixtures/task_consumer/mix.exs
+++ b/test/fixtures/task_consumer/mix.exs
@@ -31,7 +31,7 @@ defmodule TaskConsumer.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:distillery, "~> 2.0.0", runtime: false},
+      {:distillery, "~> 2.1.0", runtime: false},
       {:task_provider, ">= 0.0.0", path: System.get_env("TASK_PROVIDER_PATH"), runtime: false},
       {:bootleg, ">= 0.0.0", path: System.get_env("BOOTLEG_PATH"), runtime: false}
     ]


### PR DESCRIPTION
## Description

This PR makes bootleg compatible with Distillery 2.1.0 - see https://hexdocs.pm/distillery/changelog.html#210-unreleased.

Fixes https://github.com/labzero/bootleg/issues/299 (partially).

- `mix release` task is renamed to `mix distillery.release`
- `Mix.Releases.Config` is renamed to `Distillery.Releases.Config`
- documentation is updated to require Distillery 2.1

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Module documentation updated
- [x] Tests were added or updated to cover changes

## Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Bootleg
(the "Contribution"). My Contribution is licensed under the MIT License.

NOTE: If you submit a PR and remove the statement above, your PR will be rejected. For your PR to be
considered, it must contain your agreement to license under the MIT license.
