### PR TITLE
Fix test failure due to reuse of task names

### DIFF
--- a/test/bootleg/config_test.exs
+++ b/test/bootleg/config_test.exs
@@ -158,7 +158,10 @@ defmodule Bootleg.ConfigTest do
   end
 
   test_with_mock "env/1 starts the agent", Agent, [:passthrough], [] do
-    Config.env(:test)
+    capture_io(fn ->
+      Config.env(:test)
+    end)
+
     assert called(Agent.start_link(:test))
   end
 end

--- a/test/bootleg/dsl_test.exs
+++ b/test/bootleg/dsl_test.exs
@@ -262,8 +262,8 @@ defmodule Bootleg.DSLTest do
   test_with_mock "task/2 redefining a task shows a warning", UI, [], warn: fn _string -> :ok end do
     use Bootleg.DSL
 
-    task(:task_redefine_test, do: true)
-    task(:task_redefine_test, do: false)
+    task(:task_redefine_a, do: true)
+    task(:task_redefine_a, do: false)
     assert called(UI.warn(:_))
   end
 
@@ -271,8 +271,8 @@ defmodule Bootleg.DSLTest do
     warn: fn _string -> :ok end do
     use Bootleg.DSL
 
-    task(:task_redefine_test, do: true)
-    task(:task_redefine_test, [override: true], do: false)
+    task(:task_redefine_b, do: true)
+    task(:task_redefine_b, [override: true], do: false)
     refute called(UI.warn(:_))
   end
 
@@ -280,7 +280,7 @@ defmodule Bootleg.DSLTest do
     warn: fn _string -> :ok end do
     use Bootleg.DSL
 
-    task(:task_redefine_test, [override: true], do: true)
+    task(:task_redefine_c, [override: true], do: true)
     assert called(UI.warn(:_))
   end
 

--- a/test/fixtures/bootstraps/mix.exs
+++ b/test/fixtures/bootstraps/mix.exs
@@ -31,7 +31,7 @@ defmodule Bootstraps.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:distillery, "~> 2.0", runtime: false},
+      {:distillery, "~> 2.0.0", runtime: false},
       {:bootleg, ">= 0.0.0", path: System.get_env("BOOTLEG_PATH"), runtime: false}
     ]
   end

--- a/test/fixtures/build_me/mix.exs
+++ b/test/fixtures/build_me/mix.exs
@@ -30,6 +30,6 @@ defmodule BuildMe.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:distillery, "~> 2.0", runtime: false}]
+    [{:distillery, "~> 2.0.0", runtime: false}]
   end
 end

--- a/test/fixtures/n00b/mix.exs
+++ b/test/fixtures/n00b/mix.exs
@@ -31,7 +31,7 @@ defmodule N00b.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:distillery, "~> 2.0", runtime: false},
+      {:distillery, "~> 2.0.0", runtime: false},
       {:bootleg, ">= 0.0.0", path: System.get_env("BOOTLEG_PATH"), runtime: false}
     ]
   end

--- a/test/fixtures/task_consumer/mix.exs
+++ b/test/fixtures/task_consumer/mix.exs
@@ -31,7 +31,7 @@ defmodule TaskConsumer.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:distillery, "~> 2.0", runtime: false},
+      {:distillery, "~> 2.0.0", runtime: false},
       {:task_provider, ">= 0.0.0", path: System.get_env("TASK_PROVIDER_PATH"), runtime: false},
       {:bootleg, ">= 0.0.0", path: System.get_env("BOOTLEG_PATH"), runtime: false}
     ]


### PR DESCRIPTION
## Description

DSLTest is currently failing (reproduced with seed 753884) due to the reuse of task names. This should get it green again.

Also captures and squelches some noise about config not defined ("You are running in the `test` bootleg environment but there is no configuration defined for that environment").

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Tests were added or updated to cover changes
- [x] Commits have been squashed into a single coherent commit

## Licensing/Copyright

**By submitting this PR, you agree to the following statement, please read before submission!**

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Bootleg
(the "Contribution"). My Contribution is licensed under the MIT License.