### PR TITLE
Raise error when attempting to use undefined role

### DIFF
--- a/lib/bootleg/config.ex
+++ b/lib/bootleg/config.ex
@@ -36,7 +36,10 @@ defmodule Bootleg.Config do
   @doc false
   @spec get_role(atom) :: %Bootleg.Role{} | nil
   def get_role(name) do
-    Keyword.get(Bootleg.Config.Agent.get(:roles), name)
+    case Keyword.get(Bootleg.Config.Agent.get(:roles), name) do
+      nil -> raise "The \"#{name}\" role has not been defined, but a task is trying to use it!"
+      role -> role
+    end
   end
 
   @doc """

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,10 @@
 %{
+  "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "credo": {:hex, :credo, "0.10.2", "03ad3a1eff79a16664ed42fc2975b5e5d0ce243d69318060c626c34720a49512", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
+  "distillery": {:hex, :distillery, "2.1.1", "f9332afc2eec8a1a2b86f22429e068ef35f84a93ea1718265e740d90dd367814", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.3", "102b4f90156f59fd323be9864f7613b3f40e55d73a4cc69bcbd5cb259e0ec2bf", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/bootleg/config_test.exs
+++ b/test/bootleg/config_test.exs
@@ -68,6 +68,14 @@ defmodule Bootleg.ConfigTest do
            } = result
   end
 
+  test "get_role/1 with undefined role raises an exception" do
+    use Bootleg.DSL
+
+    assert_raise RuntimeError, ~r/role has not been defined/, fn ->
+      Config.get_role(:undef)
+    end
+  end
+
   test "load/1" do
     Config.load("test/fixtures/deploy.exs")
 

--- a/test/bootleg/tasks/invoke_task_test.exs
+++ b/test/bootleg/tasks/invoke_task_test.exs
@@ -23,7 +23,7 @@ defmodule Bootleg.Tasks.InvokeTaskTest do
                cmd_options ++ [stderr_to_stdout: true]
              )
 
-    assert String.match?(out, ~r/You must supply a %Host{}, a %Role{} or a defined role_name./)
+    assert String.match?(out, ~r/role has not been defined/)
   end
 
   test "mix bootleg.invoke", %{location: location, cmd_options: cmd_options} do


### PR DESCRIPTION
## Description

Previously, `Config.get_role(:whatever)` would return `nil` if the role didn't exist. This causes problems as we're not checking that the role exists in our built-in tasks.

Instead of returning a nil and an error being raised later on in the application, we'll just raise a more meaningful error when the role does not exist.

Fixes #307 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Tests were added or updated to cover changes
- [x] Commits have been squashed into a single coherent commit

## Licensing/Copyright

I certify that I own, and have sufficient rights to contribute, all source code and
related material intended to be compiled or integrated with the source code for Bootleg
(the "Contribution"). My Contribution is licensed under the MIT License.
